### PR TITLE
Fix typo. connectToSignallingServer is misspelled

### DIFF
--- a/library/src/Delegate/DelegateBase.ts
+++ b/library/src/Delegate/DelegateBase.ts
@@ -159,11 +159,11 @@ export class DelegateBase implements IDelegate {
 
 		this.disconnectOverlay.onAction(() => {
 			this.onWebRtcAutoConnect();
-			this.iWebRtcController.connectToSignallingSever();
+			this.iWebRtcController.connectToSignallingServer();
 		});
 
 		// Build the webRtc connect overlay Event Listener and show the connect overlay
-		this.connectOverlay.onAction(() => this.iWebRtcController.connectToSignallingSever());
+		this.connectOverlay.onAction(() => this.iWebRtcController.connectToSignallingServer());
 
 		// set up the afk overlays action 
 		this.afkOverlay.onAction(() => this.iWebRtcController.onAfkClick());
@@ -188,7 +188,7 @@ export class DelegateBase implements IDelegate {
 		} else {
 			// if autoplaying show an info overlay while while waiting for the connection to begin 
 			this.onWebRtcAutoConnect();
-			this.iWebRtcController.connectToSignallingSever();
+			this.iWebRtcController.connectToSignallingServer();
 		}
 	}
 

--- a/library/src/WebRtcPlayer/IWebRtcPlayerController.ts
+++ b/library/src/WebRtcPlayer/IWebRtcPlayerController.ts
@@ -20,7 +20,7 @@ export interface IWebRtcPlayerController {
     /**
      * Connect to the Signaling server
      */
-    connectToSignallingSever(): void;
+    connectToSignallingServer(): void;
 
     /**
      * Close the Connection to the signaling server

--- a/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -135,7 +135,7 @@ export class webRtcPlayerController implements IWebRtcPlayerController {
 		if (!this.webSocketController.webSocket) {
 			Logger.Log(Logger.GetStackTrace(), "A websocket connection has not been made yet so we will start the stream");
 			this.delegate.onWebRtcAutoConnect();
-			this.connectToSignallingSever();
+			this.connectToSignallingServer();
 
 		} else {
 			// set the replay status so we get a text overlay over an action overlay
@@ -150,7 +150,7 @@ export class webRtcPlayerController implements IWebRtcPlayerController {
 			// wait for the connection to close and restart the connection
 			let autoConnectTimeout = setTimeout(() => {
 				this.delegate.onWebRtcAutoConnect();
-				this.connectToSignallingSever();
+				this.connectToSignallingServer();
 				clearTimeout(autoConnectTimeout);
 			}, 3000);
 		}
@@ -260,7 +260,7 @@ export class webRtcPlayerController implements IWebRtcPlayerController {
 	/**
 	 * Connect to the Signaling server
 	 */
-	connectToSignallingSever() {
+	connectToSignallingServer() {
 		this.webSocketController.connect();
 	}
 
@@ -323,7 +323,7 @@ export class webRtcPlayerController implements IWebRtcPlayerController {
 
 		// if iceServers is empty return false this should not be the general use case but is here incase
 		if (!options.iceServers) {
-			Logger.Info(Logger.GetStackTrace(), 'A turn sever was not found');
+			Logger.Info(Logger.GetStackTrace(), 'A turn server was not found');
 			return false;
 		}
 
@@ -331,13 +331,13 @@ export class webRtcPlayerController implements IWebRtcPlayerController {
 		for (const iceServer of options.iceServers) {
 			for (const url of iceServer.urls) {
 				if (url.includes('turn')) {
-					Logger.Log(Logger.GetStackTrace(), `A turn sever was found at ${url}`);
+					Logger.Log(Logger.GetStackTrace(), `A turn server was found at ${url}`);
 					return true;
 				}
 			}
 		}
 
-		Logger.Info(Logger.GetStackTrace(), 'A turn sever was not found');
+		Logger.Info(Logger.GetStackTrace(), 'A turn server was not found');
 		return false;
 	}
 


### PR DESCRIPTION
I'm part of the beta program and I was going to the code when I found a typo in the code. The `connectToSignallingServer` method of `WebRtcPlayerController` is misspelled as `connectToSignallingSever`. This pull request fixes all the `connectToSignallingServer` references as well as couple misspelling of `server` in the log messages.