### PR TITLE
Added type root folders to TS Config file

### DIFF
--- a/SPS/tsconfig.json
+++ b/SPS/tsconfig.json
@@ -8,7 +8,8 @@
     "moduleResolution": "node",
     "sourceMap": false,
     "allowJs": true,
-    "declaration": false
+    "declaration": false,
+    "typeRoots" : ["./node_modules/@types", "./typings"]
   },
   "lib": ["es2015"],
   "include": ["./src/*.ts"],


### PR DESCRIPTION
For auto-completion and types to be recognized by IDEs.

Without this line, `import { Config, PixelStreaming } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.2';` gets highlighted as not found by e.g. Visual Studio Code.

If this is added, types get recognized, auto completed, it's possible to "go to definition" etc.