### PR TITLE
Upgrade SPS to new Epic Games frontend version 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 dist/
-docs/
 node_modules/
 types/
 .vscode

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # Scalable Pixel Streaming Frontend
 
-This is the web frontend for [Scalable Pixel Streaming](https://scalablestreaming.io). Documentation is a work in progress.
+This is the web frontend for [Scalable Pixel Streaming (SPS)](https://scalablestreaming.io). 
+
+The SPS frontend is a lightweight implementation of Epic Games' [Pixel Streaming frontend](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/Frontend). 
+
+## Features of the SPS Frontend
+
+- [Extensions](./SPS/src/SignallingExtension.ts) to the default signalling messages to communicate with our custom signalling server.
+- The sending of [streaming statistics](./SPS/src/SPSApplication.ts#L38) to our signalling server.
+
+## Documentation
+
+- [Migrating from SPS frontend <=0.1.4](./SPS/docs/api_transition_guide.md)
+
+## Issues
+
+As the SPS frontend is a lightweight implementation of the Epic Games frontend, the majority of issues should be reported to the Epic Games frontend [here](https://github.com/EpicGames/PixelStreamingInfrastructure/issues).
+
+However, in cases where you are certain it is an SPS specific frontend issue, please report your issue [here](https://github.com/ScalablePixelStreaming/Frontend/issues).
 
 
 ## Legal
 
-Copyright &copy; 2021 - 2022, TensorWorks Pty Ltd. Licensed under the MIT License, see the file [LICENSE](./LICENSE) for details.
+Copyright &copy; 2021 - 2023, TensorWorks Pty Ltd. Licensed under the MIT License, see the file [LICENSE](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The SPS frontend is a lightweight implementation of Epic Games' [Pixel Streaming
 
 ## Documentation
 
+In general, the official Epic Games Pixel Streaming [frontend docs](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/Frontend) should cover most common usage cases (as our library is simply a thin wrapper on that). However, some SPS frontend specific docs are listed below:
+
 - [Migrating from SPS frontend <=0.1.4](./SPS/docs/api_transition_guide.md)
 
 ## Issues

--- a/SPS/docs/api_transition_guide.md
+++ b/SPS/docs/api_transition_guide.md
@@ -1,0 +1,73 @@
+# Migrating from `libspsfrontend` <=0.1.4
+
+All SPS versions after `0.1.4` are now using the [Epic Games' Pixel Streaming frontend](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/Frontend). This shift to the Epic frontend has caused us to change both our API and our NPM packages.
+
+---
+
+# API Usage
+
+Below are common usage of SPS Frontend API that have now changed (this list is not exhaustive, if there are more you would like documented please open an issue).
+
+## Listening for UE messages
+
+**Before:** 
+```js
+iWebRtcController.dataChannelController.onResponse = (messageBuffer) => { 
+	/* whatever */ 
+}
+```
+
+**Now:**
+```js
+pixelstreaming.addResponseEventListener(name, funct)
+
+// or
+
+pixelstreaming.removeResponseEventListener(name)
+```
+
+(More details [here](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/132))
+
+---
+
+## Sending messages to UE
+
+**Before:** 
+```js
+iWebRtcController.sendUeUiDescriptor(JSON.stringify({ /* whatever */ } )) 
+```
+
+**Now:**
+```js
+pixelstreaming.emitUIInteraction(data: object | string)
+```
+
+(More details [here](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/132))
+
+---
+
+## Listen for WebRTC stream start?
+
+**Before:** 
+```js
+override onVideoInitialised()
+```
+
+**Now:**
+```js
+pixelStreaming.addEventListener("videoInitialized", ()=> { /* Do something */ });
+```
+
+(More details [here](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/110))
+
+------
+
+### NPM Packages
+The old [`libspsfrontend`](https://www.npmjs.com/package/@tensorworks/libspsfrontend) package is now deprecated in favour of [`spsfrontend`](https://www.npmjs.com/package/@tensorworks/spsfrontend).
+
+Add `spsfrontend` to your project like so:
+
+```
+npm i @tensorworks/spsfrontend
+```
+

--- a/SPS/package-lock.json
+++ b/SPS/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sps-application",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sps-application",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "devDependencies": {
         "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.1.3",

--- a/SPS/package-lock.json
+++ b/SPS/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.2.5",
       "license": "MIT",
       "devDependencies": {
-        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.1.3",
-        "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.0.4",
+        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.2.0",
+        "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.1.0",
         "css-loader": "^6.7.3",
         "html-loader": "^4.2.0",
         "html-webpack-plugin": "^5.5.0",
@@ -43,18 +43,18 @@
       }
     },
     "node_modules/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2/-/lib-pixelstreamingfrontend-ue5.2-0.1.3.tgz",
-      "integrity": "sha512-Dw4pteMCrT0JHflmJ/Wo7H/aOqA7VvhA6Msy1h7i9nfrUOGkpmiUmz+IrphwoaX9JH7Nzd/5MA//0lISIZBLiQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2/-/lib-pixelstreamingfrontend-ue5.2-0.2.0.tgz",
+      "integrity": "sha512-iFxaQfiYr76Bl0VPP/BAKNLrShoEAOPguP0TDDEav4VQ0YEnQscWNA17n86odIg5Y0c+8hDuCSEIdfXYiXYWUQ==",
       "dev": true,
       "dependencies": {
         "sdp": "^3.1.0"
       }
     },
     "node_modules/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2/-/lib-pixelstreamingfrontend-ui-ue5.2-0.0.4.tgz",
-      "integrity": "sha512-SfgvtCkZYIfcP+8BnLyjc06cXN3yWOwEzHHZ8FZ01inaNkLeXpii2pz3ciIZdDYeQ6HsDTp2O4fQMLPiA2J0hQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2/-/lib-pixelstreamingfrontend-ui-ue5.2-0.1.0.tgz",
+      "integrity": "sha512-HQBrXlNl8MkBXU+XyPpNs+eUF1kKDuJGJYbAkddxp/f6lW9d9EdHAMGLSBK8pJHMYwELrCSGYXcxQRPPzKiHJA==",
       "dev": true,
       "dependencies": {
         "jss": "^10.9.2",
@@ -62,7 +62,7 @@
         "jss-plugin-global": "^10.9.2"
       },
       "peerDependencies": {
-        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.1.1"
+        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.2.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4286,18 +4286,18 @@
       "dev": true
     },
     "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2/-/lib-pixelstreamingfrontend-ue5.2-0.1.3.tgz",
-      "integrity": "sha512-Dw4pteMCrT0JHflmJ/Wo7H/aOqA7VvhA6Msy1h7i9nfrUOGkpmiUmz+IrphwoaX9JH7Nzd/5MA//0lISIZBLiQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2/-/lib-pixelstreamingfrontend-ue5.2-0.2.0.tgz",
+      "integrity": "sha512-iFxaQfiYr76Bl0VPP/BAKNLrShoEAOPguP0TDDEav4VQ0YEnQscWNA17n86odIg5Y0c+8hDuCSEIdfXYiXYWUQ==",
       "dev": true,
       "requires": {
         "sdp": "^3.1.0"
       }
     },
     "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2/-/lib-pixelstreamingfrontend-ui-ue5.2-0.0.4.tgz",
-      "integrity": "sha512-SfgvtCkZYIfcP+8BnLyjc06cXN3yWOwEzHHZ8FZ01inaNkLeXpii2pz3ciIZdDYeQ6HsDTp2O4fQMLPiA2J0hQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2/-/lib-pixelstreamingfrontend-ui-ue5.2-0.1.0.tgz",
+      "integrity": "sha512-HQBrXlNl8MkBXU+XyPpNs+eUF1kKDuJGJYbAkddxp/f6lW9d9EdHAMGLSBK8pJHMYwELrCSGYXcxQRPPzKiHJA==",
       "dev": true,
       "requires": {
         "jss": "^10.9.2",

--- a/SPS/package.json
+++ b/SPS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sps-application",
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "The reference frontend implementation for Scalable Pixel Streaming consuming the new and improved Epic Pixel Streaming  library",
   "main": "index.ts",
   "scripts": {

--- a/SPS/package.json
+++ b/SPS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sps-application",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "The reference frontend implementation for Scalable Pixel Streaming consuming the new and improved Epic Pixel Streaming  library",
   "main": "index.ts",
   "scripts": {

--- a/SPS/package.json
+++ b/SPS/package.json
@@ -11,8 +11,8 @@
   "author": "TensorWorks Pty Ltd",
   "license": "MIT",
   "devDependencies": {
-    "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.1.3",
-    "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.0.4",
+    "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.2.0",
+    "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.1.0",
     "css-loader": "^6.7.3",
     "html-loader": "^4.2.0",
     "html-webpack-plugin": "^5.5.0",

--- a/SPS/src/index.ts
+++ b/SPS/src/index.ts
@@ -1,20 +1,26 @@
 import { SPSApplication } from "./SPSApplication";
 import { Config, PixelStreaming } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.2';
 import { PixelStreamingApplicationStyle } from '@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2';
-export const PixelStreamingApplicationStyles = new PixelStreamingApplicationStyle();
 
+// Apply default styling from Epic's frontend
+export const PixelStreamingApplicationStyles = new PixelStreamingApplicationStyle();
+PixelStreamingApplicationStyles.applyStyleSheet();
 
 document.body.onload = function () {
 
 	// Example of how to set the logger level
 	//libfrontend.Logger.SetLoggerVerbosity(10);
 
-	// Create a config object							// Extremely important, SPS only support browser sending the offer.
+	// Create a config object.
+	// Note: This config is extremely important, SPS only supports the browser sending the offer.
 	const config = new Config({ useUrlParams: true, initialSettings: { OfferToReceive: true, TimeoutIfIdle: true } });
 
 	// Create a Native DOM delegate instance that implements the Delegate interface class
 	const stream = new PixelStreaming(config);
-	const spsApplication = new SPSApplication({ stream });
+	const spsApplication = new SPSApplication({ 
+		stream,
+		onColorModeChanged: (isLightMode) => PixelStreamingApplicationStyles.setColorMode(isLightMode) /* Light/Dark mode support. */
+	});
 
 	document.body.appendChild(spsApplication.rootElement);
 }


### PR DESCRIPTION
- Upgrade lib-pixelstreamingfrontend version to 0.2.0
- Upgrade lib-pixelstreamingfrontend-ui version to 0.1.0
- Write migration guide for SPS customers on versions prior to using the Epic frontend
- Update readme.md with more information and relevant links
- Bump sps version to 1.0.0 due to API breaking changes introduced in the shift to new frontend