### PR TITLE
Added Tag and Release Workflows and container building scripts for Frontend

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -1,14 +1,17 @@
-name: Publish library package to npmjs
-on:
-  push:
-    tags:
-      - "*"
+name: Scalable Pixel Streaming Frontend Release Workflow Pipeline
+
+# Start our pipeline when we create a new tag on the master branch
+on: 
+  release:
+    types: [published]
+    
 jobs:
-  build:
+  # Build NPM Package
+  build-npm:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./SPS
+        working-directory: ./library
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/tag-workflow.yaml
+++ b/.github/workflows/tag-workflow.yaml
@@ -1,0 +1,82 @@
+name: Scalable Pixel Streaming Frontend Tag Workflow Pipeline
+
+# Start our pipeline when we create a new tag on the master branch
+on:
+  push:
+    tags:
+      - '*'
+    
+# Assign an environment variable that we can use throughout the workflow for the version
+# of SPS that we are tagging
+env:
+  FRONTEND_VERSION: ${{ github.ref_name }}
+  DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+  DOCKER_TOKEN: ${{ secrets.DOCKER_ACCESS_KEY }}
+
+jobs:
+
+  # Build AWS
+  build-aws:
+
+    runs-on: ubuntu-latest
+
+    env:
+      CLOUD_PROVIDER: aws
+
+    steps:
+
+    - name: Free up some space
+      run: |
+        sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+        sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+    
+    # Clone the source code on the runner
+    - name: Clone repository
+      uses: actions/checkout@v3
+
+    # Setup GO
+    - name: Set up GO
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+
+      # Login to Docker
+    - name: Docker login
+      run: docker login -u $DOCKER_USER -p $DOCKER_TOKEN
+
+    # Install zip
+    - name: Install zip
+      uses: montudor/action-zip@v1
+
+      # Build the Docker images that are part of the core framework (non cloud platform specific images)
+    - name: Build core framework images and push to Docker
+      run: |
+        ./.scripts/linux/pipeline/build-images-core.sh --version $FRONTEND_VERSION --provider $CLOUD_PROVIDER
+
+  # Build CoreWeave
+  build-coreweave:
+
+    runs-on: ubuntu-latest
+
+    env:
+      CLOUD_PROVIDER: coreweave
+
+    steps: 
+
+    # Clone the source code on the runner
+    - name: Clone repository
+      uses: actions/checkout@v3
+
+    # Setup GO
+    - name: Set up GO
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+
+      # Login to Docker
+    - name: Docker login
+      run: docker login -u $DOCKER_USER -p $DOCKER_TOKEN
+
+      # Build the Docker images that are part of the core framework (non cloud platform specific images)
+    - name: Build core framework images and push to Docker
+      run: ./.scripts/linux/pipeline/build-images-core.sh --version $FRONTEND_VERSION --provider $CLOUD_PROVIDER

--- a/.scripts/linux/pipeline/build-images-core.sh
+++ b/.scripts/linux/pipeline/build-images-core.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# The version we're building, defaults to dev
+VERSION=0.0.0-devel
+CLOUD_PROVIDER=local
+
+# Read the version flag if given
+num=0
+for var in "$@"
+do
+    eval flag="\$$num"
+
+    if [[ $flag == "--provider" ]]; then
+        ((num=num+1))
+        eval CLOUD_PROVIDER="\$$num"
+    fi
+
+    if [[ $flag == "--version" ]]; then
+        ((num=num+1))
+        eval VERSION="\$$num"
+    fi
+
+    ((num=num+1))
+
+done
+
+# Define our base images
+IMG_HTTP_SERVER="tensorworks/sps-http-server"
+
+# Build all our core containers as background tasks
+echo -e '*\n!bin/linux/amd64/*' > .dockerignore
+docker build -t "$IMG_HTTP_SERVER:$VERSION-$CLOUD_PROVIDER" -f dockerfiles/http-server.dockerfile .
+
+# push them containers to docker (3 at a time)
+docker push "$IMG_HTTP_SERVER:$VERSION-$CLOUD_PROVIDER"

--- a/dockerfiles/http-server.dockerfile
+++ b/dockerfiles/http-server.dockerfile
@@ -1,0 +1,24 @@
+
+FROM timbru31/node-alpine-git:16 as builder
+
+ARG VERSION=v1.0.0
+
+RUN git clone https://github.com/ScalablePixelStreaming/Frontend.git -b $VERSION
+
+RUN (cd Frontend && cd ./&& npm install && npm run build)
+
+RUN mkdir www
+
+RUN cp -a ./Frontend/dist/. www
+
+FROM nginx:1.21.6
+
+RUN mkdir www
+WORKDIR /www
+
+COPY --from=builder www ./
+
+RUN rm /etc/nginx/nginx.conf
+RUN ln -s /etc/nginx/sps/nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80


### PR DESCRIPTION
Aim: To separate the release of the SPS Frontend from the SPS Framework by adding the ability to tag and release container images of the frontend and to push the frontend npm package all from the frontend repo sepera. 

What was added: 
1) tag-workflow.yaml: the github workflow for building container images upon taging 
2) release-workflow.yaml: the github workflow for building and pushing the frontend to NPM when making a github release. 
3) build-images-core.sh: the script that gets our cloud provider and version and builds and pushes our docker container
4) http-server.dockerfile: the script that gets executed in build-images-core to build our docker container from our npm taged repo