### PR TITLE
Add a GitHub actions workflow that does test builds for pull requests

### DIFF
--- a/.github/workflows/test-pull-request.yaml
+++ b/.github/workflows/test-pull-request.yaml
@@ -7,7 +7,7 @@ on: pull_request
 jobs:
 
   # This job will checkout the repo, install dependencies and then build the frontend package
-  test-build-frontend:
+  test-build-frontend-and-lib:
     runs-on: ubuntu-latest
 
     # set out working directory
@@ -26,8 +26,10 @@ jobs:
         with:
           node-version: "16.x"
 
-      - name: Install dependencies and build
+      # install deps for frontend and library and build both
+      - name: Install library and frontend deps and build
+        working-directory: ./examples/typescript
         id: npm
         run: |
-          npm install
-          npm run build
+          npm ci
+          npm run build-all

--- a/.github/workflows/test-pull-request.yaml
+++ b/.github/workflows/test-pull-request.yaml
@@ -1,0 +1,33 @@
+# The following workflow will run when a pull request is opened, synched or reopened
+# It's intent is to run a build of the package against the PR to ensure that it passes a code build check
+
+name: test-build
+on: pull_request
+    
+jobs:
+
+  # This job will checkout the repo, install dependencies and then build the frontend package
+  test-build-frontend:
+    runs-on: ubuntu-latest
+
+    # set out working directory
+    defaults:
+      run:
+        working-directory: ./
+
+    # checkout, install node and run our npm commands to check code builds
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+
+      - name: Install dependencies and build
+        id: npm
+        run: |
+          npm install
+          npm run build


### PR DESCRIPTION
## Relevant components:
- GitHub Actions workflow

## Problem statement:
Lack of tests running to ensure that our packages can always build

## Solution
Introduces a GitHub Actions workflow that will run when a pull request is `opened`, `synched` or `reopened`
This essentially means on create and on every commit made to the PR, this workflow will run and check that the package can continue to build.

## Test Plan and Compatibility
Check this [pull request](https://github.com/dan-tw/Frontend/pull/1) for an example

The above demonstrates a commit that has been made to a PR that is causing the test to fail.
