### PR TITLE
Fix for incorrectly named module import 'lib-spsfrontend', changed to 'libspsfrontend'

### DIFF
--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@tensorworks/lib-spsfrontend": "^1.0.0",
         "@types/node": "^18.15.1",
         "@types/webpack": "^5.28.0",
         "@webpack-cli/generators": "^3.0.1",
@@ -29,7 +28,7 @@
       }
     },
     "../..": {
-      "name": "@tensorworks/lib-spsfrontend",
+      "name": "@tensorworks/libspsfrontend",
       "version": "1.0.0",
       "extraneous": true,
       "license": "MIT",
@@ -668,12 +667,6 @@
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
       }
-    },
-    "node_modules/@tensorworks/spsfrontend": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@tensorworks/spsfrontend/-/spsfrontend-0.2.5.tgz",
-      "integrity": "sha512-NtkVWXoRuK6m6is+9UPick+Iymp9gzqJwnqhRBpnN8yqJ3WSmP1Q4y30WJ349JePuWadRU2W70lX09xEyXQb/A==",
-      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -8940,12 +8933,6 @@
       "requires": {
         "@octokit/openapi-types": "^12.11.0"
       }
-    },
-    "@tensorworks/spsfrontend": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@tensorworks/spsfrontend/-/spsfrontend-0.2.5.tgz",
-      "integrity": "sha512-NtkVWXoRuK6m6is+9UPick+Iymp9gzqJwnqhRBpnN8yqJ3WSmP1Q4y30WJ349JePuWadRU2W70lX09xEyXQb/A==",
-      "dev": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -1,4 +1,4 @@
-import * as spsFrontend from "@tensorworks/lib-spsfrontend";
+import * as spsFrontend from "@tensorworks/libspsfrontend";
 
 // Apply default styling from Epic's frontend
 export const PixelStreamingApplicationStyles = new spsFrontend.PixelStreamingApplicationStyle();
@@ -12,7 +12,7 @@ document.body.onload = function () {
 
 	// Create a Native DOM delegate instance that implements the Delegate interface class
 	const stream = new spsFrontend.PixelStreaming(config);
-	const spsApplication = new spsFrontend.SPSApplication({ 
+	const spsApplication = new spsFrontend.SPSApplication({
 		stream,
 		onColorModeChanged: (isLightMode) => PixelStreamingApplicationStyles.setColorMode(isLightMode) /* Light/Dark mode support. */
 	});


### PR DESCRIPTION
## Relevant components:
- spsfrontend

## Problem statement:
Incorrectly named import of the module `@tensorworks/lib-spsfrontend`

## Solution
Correctly named import of the module to `@tensorworks/libspsfrontend`

## Test Plan and Compatibility
The libspsfrontend and spsfrontend packages now build without errors.