### PR TITLE
Add data property on the MessageRequestInstance 

### DIFF
--- a/library/src/SignallingExtension.ts
+++ b/library/src/SignallingExtension.ts
@@ -66,6 +66,10 @@ export class MessageAuthResponse extends MessageRecv {
  * Instance Request Message Wrapper
  */
 export class MessageRequestInstance extends MessageSend {
+
+	// An opaque string representing optional configuration data to pass to the signalling server for instance customisation
+	data: string
+
 	constructor() {
 		super();
 		this.type = "requestInstance";


### PR DESCRIPTION
## Relevant components:
- libspsfrontend

## Problem statement:
There was no `data` property on the `MessageRequestInstance` to allow an opaque string representing optional configuration data to pass to the signalling server for instance customisation 

## Solution
Added a `data` property

## Documentation
-

## Test Plan and Compatibility
Confirmed that the data does get sent via the `requestInstance` websocket