### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The SPS frontend is a lightweight implementation of Epic Games' [Pixel Streaming
 
 ## Features of the SPS Frontend
 
-- [Extensions](./src/SignallingExtension.ts) to the default signalling messages to communicate with our custom signalling server.
-- The sending of [streaming statistics](./src/SPSApplication.ts#L38) to our signalling server.
+- [Extensions](./library/src/SignallingExtension.ts) to the default signalling messages to communicate with our custom signalling server.
+- The sending of [streaming statistics](./library/src/SPSApplication.ts#L38) to our signalling server.
 
 ## Documentation
 


### PR DESCRIPTION
## Relevant components:
- [ ] Scalable Pixel Streaming Frontend library
- [ ] Examples
- [x] Docs

## Problem statement:
Fixes broken links in README.MD

## Solution
Changed hyperlinks to have `./library`

## Documentation
N/A

## Test Plan and Compatibility
Clicked the links in the markdown preview in Github and saw they went to the right place.