### PR TITLE
Updated the epic games pixel streaming frontend to 0.5.1

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.0",
+        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.1",
         "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.4.0"
       },
       "devDependencies": {
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2/-/lib-pixelstreamingfrontend-ue5.2-0.5.0.tgz",
-      "integrity": "sha512-X26GfWTh20nmX1bY5bT/FuuI1gy21A+Jspef93mkqlbFJ+WOLXzVRxyxJ9vxBKlMf2MNl9XZdnTknfXgyRLUaA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2/-/lib-pixelstreamingfrontend-ue5.2-0.5.1.tgz",
+      "integrity": "sha512-u7Ai08nZjvL3xPMz76Bk1X6g1yovMxySUVxUdUSQzREH11FECfT0riTnpNTBPxZlTEsjAEu4/H+ewI0FAKiQOw==",
       "dependencies": {
         "sdp": "^3.1.0"
       }
@@ -4325,9 +4325,9 @@
       "dev": true
     },
     "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2/-/lib-pixelstreamingfrontend-ue5.2-0.5.0.tgz",
-      "integrity": "sha512-X26GfWTh20nmX1bY5bT/FuuI1gy21A+Jspef93mkqlbFJ+WOLXzVRxyxJ9vxBKlMf2MNl9XZdnTknfXgyRLUaA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.2/-/lib-pixelstreamingfrontend-ue5.2-0.5.1.tgz",
+      "integrity": "sha512-u7Ai08nZjvL3xPMz76Bk1X6g1yovMxySUVxUdUSQzREH11FECfT0riTnpNTBPxZlTEsjAEu4/H+ewI0FAKiQOw==",
       "requires": {
         "sdp": "^3.1.0"
       }

--- a/library/package.json
+++ b/library/package.json
@@ -14,7 +14,7 @@
   "author": "TensorWorks Pty Ltd",
   "license": "MIT",
   "dependencies": {
-    "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.0",
+    "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.1",
     "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Relevant components:
- [X] Scalable Pixel Streaming Frontend library
- [ ] Examples
- [ ] Docs

## Problem statement:
This PR will update the Epic Games Frontend Library to use version 0.5.1 and this will eliminate the auto connecting issue. 

## Solution
This PR solves the issue by using the new version of the Epic Games Frontend Library which uses the boolean variable `shouldReconnect` set to `false`. This also fixes a bug with the restart stream button not restarting the stream correctly.  

## Documentation
None required as this will be default behavior

## Test Plan and Compatibility
Wait for the SPS Frontend to afk disconnect or induce a disconnect and the stream will not auto reconnect. 
