### PR TITLE
Bumped Scalable Pixel Streaming Frontend Library version to 0.3.3

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorworks/libspsfrontend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "The Scalable Pixel Streaming Frontend Library consuming Epic Games' Pixel Streaming Frontend",
   "main": "dist/libspsfrontend.min.js",
   "module": "dist/libspsfrontend.esm.js",


### PR DESCRIPTION
## Relevant components:
- [X] Scalable Pixel Streaming Frontend library
- [ ] Examples
- [ ] Docs

## Problem statement:
Updates the Scalable Pixel Streaming Frontend Library is v0.3.2 and it needs to be updated to v0.3.3

## Solution
The Package.json version in the library needs to be updated to 0.3.3
