### PR TITLE
Extend the handleOnConfig from the PS library so we are able to include an engine version to determine if we need to send our WebRTC offer from the frontend or from the UE instance

### DIFF
--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -38,7 +38,7 @@ document.body.onload = function () {
 	// Override the onConfig so we can determine if we need to send the WebRTC offer based on the engine version
 	// If the engine version is 4.27 or not defined, the browser should send the offer. This is what the Scalable Pixel Streaming signalling server will be expecting.
 	stream.webSocketController.onConfig = (messageExtendedConfig: MessageExtendedConfig) => {
-		stream.config.setFlagEnabled(Flags.BrowserSendOffer, (messageExtendedConfig.engineVersion == "4.27" || messageExtendedConfig.engineVersion == "5.0" || messageExtendedConfig.engineVersion == ""));
+		stream.config.setFlagEnabled(Flags.BrowserSendOffer, (messageExtendedConfig.engineVersion == "4.27" || messageExtendedConfig.engineVersion == ""));
 		stream.handleOnConfig(messageExtendedConfig);
 	}
 

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -1,4 +1,4 @@
-import {Config, PixelStreaming, SPSApplication, TextParameters, PixelStreamingApplicationStyle} from "@tensorworks/libspsfrontend";
+import { Config, PixelStreaming, SPSApplication, TextParameters, PixelStreamingApplicationStyle, MessageRecv, Flags } from "@tensorworks/libspsfrontend";
 
 // Apply default styling from Epic Games Pixel Streaming Frontend
 export const PixelStreamingApplicationStyles = new PixelStreamingApplicationStyle();
@@ -7,24 +7,45 @@ PixelStreamingApplicationStyles.applyStyleSheet();
 // websocket url env
 declare var WEBSOCKET_URL: string;
 
+// Extend the MessageRecv to allow the engine version to exist as part of our config message from the signalling server
+class MessageExtendedConfig extends MessageRecv {
+	peerConnectionOptions: RTCConfiguration;
+	engineVersion: string
+};
+
+// Extend PixelStreaming to use our custom extended config that includes the engine version
+class ScalablePixelStreaming extends PixelStreaming {
+	// Create a new method that retains original functionality
+	public handleOnConfig(messageExtendedConfig: MessageExtendedConfig) {
+		this._webRtcController.handleOnConfigMessage(messageExtendedConfig)
+	}
+};
+
 document.body.onload = function () {
 
-	// Create a config object.
-	// Note: This config is extremely important, SPS only supports the browser sending the offer.
+	// Create a config object. We default to sending the WebRTC offer from the browser as true
 	const config = new Config({ useUrlParams: true, initialSettings: { OfferToReceive: true, TimeoutIfIdle: true } });
 
 	// make usage of WEBSOCKET_URL if it is not empty
 	let webSocketAddress = WEBSOCKET_URL;
-	if(webSocketAddress != ""){
+	if (webSocketAddress != "") {
 		config.setTextSetting(TextParameters.SignallingServerUrl, webSocketAddress)
 	}
 
 	// Create stream and spsApplication instances that implement the Epic Games Pixel Streaming Frontend PixelStreaming and Application types
-	const stream = new PixelStreaming(config);
+	const stream = new ScalablePixelStreaming(config);
+
+	// Override the onConfig so we can determine if we need to send the WebRTC offer based on the engine version
+	// If the engine version is 4.27 or not defined, the browser should send the offer. This is what the Scalable Pixel Streaming signalling server will be expecting.
+	stream.webSocketController.onConfig = (messageExtendedConfig: MessageExtendedConfig) => {
+		stream.config.setFlagEnabled(Flags.BrowserSendOffer, (messageExtendedConfig.engineVersion == "4.27" || messageExtendedConfig.engineVersion == ""));
+		stream.handleOnConfig(messageExtendedConfig);
+	}
+
+	// Create and append our application
 	const spsApplication = new SPSApplication({
 		stream,
 		onColorModeChanged: (isLightMode) => PixelStreamingApplicationStyles.setColorMode(isLightMode) /* Light/Dark mode support. */
 	});
-
 	document.body.appendChild(spsApplication.rootElement);
 }

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -38,7 +38,7 @@ document.body.onload = function () {
 	// Override the onConfig so we can determine if we need to send the WebRTC offer based on the engine version
 	// If the engine version is 4.27 or not defined, the browser should send the offer. This is what the Scalable Pixel Streaming signalling server will be expecting.
 	stream.webSocketController.onConfig = (messageExtendedConfig: MessageExtendedConfig) => {
-		stream.config.setFlagEnabled(Flags.BrowserSendOffer, (messageExtendedConfig.engineVersion == "4.27" || messageExtendedConfig.engineVersion == ""));
+		stream.config.setFlagEnabled(Flags.BrowserSendOffer, (messageExtendedConfig.engineVersion == "4.27" || messageExtendedConfig.engineVersion == "5.0" || messageExtendedConfig.engineVersion == ""));
 		stream.handleOnConfig(messageExtendedConfig);
 	}
 

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitAny": true,
     "module": "es6",
     "esModuleInterop": true,
-    "target": "es5",
+    "target": "ES6",
     "moduleResolution": "node",
     "sourceMap": false,
     "allowJs": true,

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@tensorworks/libspsfrontend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tensorworks/libspsfrontend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.1",
-        "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.4.0"
+        "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.4.1"
       },
       "devDependencies": {
         "css-loader": "^6.7.3",
@@ -53,16 +53,17 @@
       }
     },
     "node_modules/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2/-/lib-pixelstreamingfrontend-ui-ue5.2-0.4.0.tgz",
-      "integrity": "sha512-WwIUMMMxRDbo+LTt/t3b24qNhTX4d4TuWoj4Ynw37fX8SHLFvJ++9U0ByP3bRxyw9scRBNTVtCZ/6kZIzJV2fQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2/-/lib-pixelstreamingfrontend-ui-ue5.2-0.4.1.tgz",
+      "integrity": "sha512-GXwB4/LS2fcVyfTAHe6Ma90+Z+oxNIIiwowe0S5ItgsGn2DPo1KwhDw7AbIsbqgtJDntKoofuzrtcdU6lG4RNw==",
+      "license": "MIT",
       "dependencies": {
         "jss": "^10.9.2",
         "jss-plugin-camel-case": "^10.9.2",
         "jss-plugin-global": "^10.9.2"
       },
       "peerDependencies": {
-        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.0"
+        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.1"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4333,9 +4334,9 @@
       }
     },
     "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2/-/lib-pixelstreamingfrontend-ui-ue5.2-0.4.0.tgz",
-      "integrity": "sha512-WwIUMMMxRDbo+LTt/t3b24qNhTX4d4TuWoj4Ynw37fX8SHLFvJ++9U0ByP3bRxyw9scRBNTVtCZ/6kZIzJV2fQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2/-/lib-pixelstreamingfrontend-ui-ue5.2-0.4.1.tgz",
+      "integrity": "sha512-GXwB4/LS2fcVyfTAHe6Ma90+Z+oxNIIiwowe0S5ItgsGn2DPo1KwhDw7AbIsbqgtJDntKoofuzrtcdU6lG4RNw==",
       "requires": {
         "jss": "^10.9.2",
         "jss-plugin-camel-case": "^10.9.2",

--- a/library/package.json
+++ b/library/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.1",
-    "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.4.0"
+    "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.2": "^0.4.1"
   },
   "devDependencies": {
     "css-loader": "^6.7.3",


### PR DESCRIPTION
## Relevant components:
- [x] Scalable Pixel Streaming Frontend library
- [x] Examples

## Problem statement:
We needed a way to differentiate what engine version was being negotiated via WebRTC as their behaviour can differ from version to version. Specifically, we wanted a way to be able to say when we should be sending WebRTC offers from the frontend and when we should be sending WebRTC offers from the instance.

## Solution
This PR allows the frontend to receive a custom config message from the signalling server that includes the engine version of the instance that the frontend is attempting to negotiate it's WebRTC handshake with. Using this engine version, we override the flag that tells the frontend whether or not to send the WebRTC offer.

We only send a WebRTC offer from the frontend when the engine version is 4.27 or when it is empty. 

## Documentation
N/A

## Test Plan and Compatibility
Testing across engine versions for both Linux and Windows.