### PR TITLE
Replaced the logic to send the offer from the frontend depending on what is sent from the signalling server

### DIFF
--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -11,6 +11,8 @@ declare var WEBSOCKET_URL: string;
 class MessageExtendedConfig extends MessageRecv {
 	peerConnectionOptions: RTCConfiguration;
 	engineVersion: string
+	platform: string
+	frontendToSendOffer: boolean
 };
 
 // Extend PixelStreaming to use our custom extended config that includes the engine version
@@ -35,10 +37,9 @@ document.body.onload = function () {
 	// Create stream and spsApplication instances that implement the Epic Games Pixel Streaming Frontend PixelStreaming and Application types
 	const stream = new ScalablePixelStreaming(config);
 
-	// Override the onConfig so we can determine if we need to send the WebRTC offer based on the engine version
-	// If the engine version is 4.27 or not defined, the browser should send the offer. This is what the Scalable Pixel Streaming signalling server will be expecting.
+	// Override the onConfig so we can determine if we need to send the WebRTC offer based on what is sent from the signalling server
 	stream.webSocketController.onConfig = (messageExtendedConfig: MessageExtendedConfig) => {
-		stream.config.setFlagEnabled(Flags.BrowserSendOffer, (messageExtendedConfig.engineVersion == "4.27" || messageExtendedConfig.engineVersion == ""));
+		stream.config.setFlagEnabled(Flags.BrowserSendOffer, messageExtendedConfig.frontendToSendOffer);
 		stream.handleOnConfig(messageExtendedConfig);
 	}
 

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -10,16 +10,16 @@ declare var WEBSOCKET_URL: string;
 // Extend the MessageRecv to allow the engine version to exist as part of our config message from the signalling server
 class MessageExtendedConfig extends MessageRecv {
 	peerConnectionOptions: RTCConfiguration;
-	engineVersion: string
-	platform: string
-	frontendToSendOffer: boolean
+	engineVersion: string;
+	platform: string;
+	frontendToSendOffer: boolean;
 };
 
 // Extend PixelStreaming to use our custom extended config that includes the engine version
 class ScalablePixelStreaming extends PixelStreaming {
 	// Create a new method that retains original functionality
 	public handleOnConfig(messageExtendedConfig: MessageExtendedConfig) {
-		this._webRtcController.handleOnConfigMessage(messageExtendedConfig)
+		this._webRtcController.handleOnConfigMessage(messageExtendedConfig);
 	}
 };
 
@@ -31,7 +31,7 @@ document.body.onload = function () {
 	// make usage of WEBSOCKET_URL if it is not empty
 	let webSocketAddress = WEBSOCKET_URL;
 	if (webSocketAddress != "") {
-		config.setTextSetting(TextParameters.SignallingServerUrl, webSocketAddress)
+		config.setTextSetting(TextParameters.SignallingServerUrl, webSocketAddress);
 	}
 
 	// Create stream and spsApplication instances that implement the Epic Games Pixel Streaming Frontend PixelStreaming and Application types


### PR DESCRIPTION
## Relevant components:
- [ ] Scalable Pixel Streaming Frontend library
- [x] Examples
- [ ] Docs

## Problem statement:
Currently there is logic to handle sending the webRTC offer based on the engine version. A new property has been introduced to remove this logic.

## Solution
The logic to determine if the frontend sends the webRTC offer is replaced with the `frontendToSendOffer` property as from the config message that is sent from the signalling server.

## Test Plan and Compatibility

### Prerequisites

1. Installed sps to aws using a 0.0.0-devel version
2. Added the sps details to the sps-cli config
3. Ran the frontend locally
```sh
cd examples/typescript
npm run serve-dev
```

### `frontendToSendOffer` set to `true`

1. Deploy a new application using the CLI Tool using the following command.
```
./sps-client application create --name offer
```

2. Deploy a version to the `offer` application with the `frontendToSendOffer` set to `true` using the following JSON data and command.

offer-v1.json
```json
{
  "name": "v1",
  "buildOptions": {
    "input": {
      "containerTag": "tensorworks/ue:5.0-linux"
    }
  },
  "runtimeOptions": {
    "pixelStreaming": {
      "webRTC": {
        "frontendToSendOffer": true
      }
    }
  }
}
```

```sh
./sps-client version create --filepath offer-v1.json --application offer
```

3. Set the `activeVersion` of application `offer` to `v1`.
```sh
./sps-client application update --name offer --activeVersion v1
```

4. Retrieved the websocket address for the application and set the webSocketAddress.
```ts
let webSocketAddress = "ws://sps-dave-2023051701-283060373.ap-northeast-1.elb.amazonaws.com/offer/ws";
```

5. Clicked to start the instance

6. Wait for the instance to start

7. Click the Gear in the top left corner

8. The value of the `Browser send offer` options will be `on`


### `frontendToSendOffer` set to `false`

1. Deploy a new application using the CLI Tool using the following command.
```
./sps-client application create --name no-offer
```

2. Deploy a version to the `no-offer` application with the `frontendToSendOffer` set to `false` using the following JSON data and command.

no-offer-v1.json
```json
{
  "name": "v1",
  "buildOptions": {
    "input": {
      "containerTag": "tensorworks/ue:5.0-linux"
    }
  },
  "runtimeOptions": {
    "pixelStreaming": {
      "webRTC": {
        "frontendToSendOffer": false
      }
    }
  }
}
```

```sh
./sps-client version create --filepath offer-v1.json --application no-offer
```

3. Set the `activeVersion` of application `no-offer` to `v1`.
```sh
./sps-client application update --name no-offer --activeVersion v1
```

4. Retrieved the websocket address for the application and set the webSocketAddress.
```ts
let webSocketAddress = "ws://sps-dave-2023051701-283060373.ap-northeast-1.elb.amazonaws.com/no-offer/ws";
```

5. Clicked to start the instance

6. Wait for the instance to start

7. Click the Gear in the top left corner

8. The value of the `Browser send offer` options will be `off`
