### PR TITLE
Set the autoConnect to false and the maxReconnects attempts to 0

### DIFF
--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -25,8 +25,8 @@ class ScalablePixelStreaming extends PixelStreaming {
 
 document.body.onload = function () {
 
-	// Create a config object. We default to sending the WebRTC offer from the browser as true
-	const config = new Config({ useUrlParams: true, initialSettings: { OfferToReceive: true, TimeoutIfIdle: true } });
+	// Create a config object. We default to sending the WebRTC offer from the browser as true, TimeoutIfIdle to true, AutoConnect to false and MaxReconnectAttempts to 0
+	const config = new Config({ useUrlParams: true, initialSettings: { OfferToReceive: true, TimeoutIfIdle: true, AutoConnect: false, MaxReconnectAttempts: 0 } });
 
 	// make usage of WEBSOCKET_URL if it is not empty
 	let webSocketAddress = WEBSOCKET_URL;


### PR DESCRIPTION
## Relevant components:
- [ ] Scalable Pixel Streaming Frontend library
- [x] Examples
- [ ] Docs

## Problem statement:
The frontend will auto reconnect making it difficult to debug

## Solution
this sets the AutoConnect and MaxReconnectAttempts to 0 to stop the frontend from reconnecting and starting a new sps instance

## Documentation

## Test Plan and Compatibility
Built and tested locally and connected to a remote cluster
