### PR TITLE
Change how the signalling URL is built

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tensorworks/libspsfrontend",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tensorworks/libspsfrontend",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.1",

--- a/library/src/SPSApplication.ts
+++ b/library/src/SPSApplication.ts
@@ -54,12 +54,13 @@ export class SPSApplication extends Application {
 
 	enforceSpecialSignallingServerUrl() {
 		// SPS needs a special /ws added to the signalling server url so K8s can distinguish it
-		this.stream.setSignallingUrlBuilder(()=> {
+		this.stream.setSignallingUrlBuilder(() => {
+
+			// get the current signalling url
 			let signallingUrl = this.stream.config.getTextSettingValue(TextParameters.SignallingServerUrl);
 
-			if (signallingUrl && signallingUrl !== undefined && !signallingUrl.endsWith("/ws")) {
-				signallingUrl = signallingUrl.endsWith("/") ? signallingUrl + "ws" : signallingUrl + window.location.pathname + "/ws";
-			}
+			// add our 'ws' token to the end dependant on whether the URL ends with a '/' or not
+			signallingUrl = signallingUrl.endsWith("/") ? signallingUrl + "signalling" + window.location.pathname : signallingUrl + "/signalling" + window.location.pathname;
 
 			return signallingUrl
 		});


### PR DESCRIPTION

## Relevant components:
- [x] Scalable Pixel Streaming Frontend library

## Problem statement:
The signalling server URL builder needed to be updated to support the new 'custom frontend' feature of SPS.

## Solution
Change how the signalling URL is built. We now use host.com/application-name/signalling as the default structure for the signalling websocket. This is due to a change in Scalable Pixel Streaming towards supporting custom frontends on a per application/version basis


## Documentation
TBD

## Test Plan and Compatibility
It works.