### PR TITLE
Reinstate the ability to override the signalling server URL using the .env file for local testing

### DIFF
--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -4,9 +4,6 @@ import { Config, PixelStreaming, SPSApplication, TextParameters, PixelStreamingA
 export const PixelStreamingApplicationStyles = new PixelStreamingApplicationStyle();
 PixelStreamingApplicationStyles.applyStyleSheet();
 
-// websocket url env
-declare var WEBSOCKET_URL: string;
-
 // Extend the MessageRecv to allow the engine version to exist as part of our config message from the signalling server
 class MessageExtendedConfig extends MessageRecv {
 	peerConnectionOptions: RTCConfiguration;
@@ -27,12 +24,6 @@ document.body.onload = function () {
 
 	// Create a config object. We default to sending the WebRTC offer from the browser as true, TimeoutIfIdle to true, AutoConnect to false and MaxReconnectAttempts to 0
 	const config = new Config({ useUrlParams: true, initialSettings: { OfferToReceive: true, TimeoutIfIdle: true, AutoConnect: false, MaxReconnectAttempts: 0 } });
-
-	// make usage of WEBSOCKET_URL if it is not empty
-	let webSocketAddress = WEBSOCKET_URL;
-	if (webSocketAddress != "") {
-		config.setTextSetting(TextParameters.SignallingServerUrl, webSocketAddress);
-	}
 
 	// Create stream and spsApplication instances that implement the Epic Games Pixel Streaming Frontend PixelStreaming and Application types
 	const stream = new ScalablePixelStreaming(config);

--- a/library/src/SPSApplication.ts
+++ b/library/src/SPSApplication.ts
@@ -4,7 +4,7 @@ import { LoadingOverlay } from './LoadingOverlay';
 import { SPSSignalling } from './SignallingExtension';
 import { MessageStats } from './Messages';
 
-//  For local testing. Declare a websocket URL that can be imported via a .env file that will override 
+// For local testing. Declare a websocket URL that can be imported via a .env file that will override 
 // the signalling server URL builder.
 declare var WEBSOCKET_URL: string;
 

--- a/library/src/SPSApplication.ts
+++ b/library/src/SPSApplication.ts
@@ -57,7 +57,7 @@ export class SPSApplication extends Application {
 	}
 
 	enforceSpecialSignallingServerUrl() {
-		// SPS needs a special to build a specific signalling server url so K8s can distinguish it
+		// SPS needs to build a specific signalling server url based on the application name so K8s can distinguish it
 		this.stream.setSignallingUrlBuilder(() => {
 
 			// if we have overriden the signalling server URL with a .env file use it here

--- a/library/src/SPSApplication.ts
+++ b/library/src/SPSApplication.ts
@@ -4,6 +4,10 @@ import { LoadingOverlay } from './LoadingOverlay';
 import { SPSSignalling } from './SignallingExtension';
 import { MessageStats } from './Messages';
 
+//  For local testing. Declare a websocket URL that can be imported via a .env file that will override 
+// the signalling server URL builder.
+declare var WEBSOCKET_URL: string;
+
 
 export class SPSApplication extends Application {
 	private loadingOverlay: LoadingOverlay;
@@ -53,13 +57,18 @@ export class SPSApplication extends Application {
 	}
 
 	enforceSpecialSignallingServerUrl() {
-		// SPS needs a special /ws added to the signalling server url so K8s can distinguish it
+		// SPS needs a special to build a specific signalling server url so K8s can distinguish it
 		this.stream.setSignallingUrlBuilder(() => {
+
+			// if we have overriden the signalling server URL with a .env file use it here
+			if (WEBSOCKET_URL) {
+				return WEBSOCKET_URL as string;
+			}
 
 			// get the current signalling url
 			let signallingUrl = this.stream.config.getTextSettingValue(TextParameters.SignallingServerUrl);
 
-			// add our 'ws' token to the end dependant on whether the URL ends with a '/' or not
+			// build the signalling URL based on the existing window location, the result should be 'domain.com/signalling/app-name'
 			signallingUrl = signallingUrl.endsWith("/") ? signallingUrl + "signalling" + window.location.pathname : signallingUrl + "/signalling" + window.location.pathname;
 
 			return signallingUrl


### PR DESCRIPTION
## Relevant components:
- [x] Scalable Pixel Streaming Frontend library
- [x] Examples

## Problem statement:
We had lost the ability to override the signalling server address for local testing

## Solution
declare a `WEBSOCKET_URL` variable via the `.env` file that, if set, will be loaded in when running local dev testing and replace the signalling server URL builder functionality.

## Documentation
Inside `examples/typescript` there is a `.env.example` file. Changing this to `.env` and changing the `WEBSOCKET_URL` to your custom websocket address will override the signalling server URL builder during testing

## Test Plan and Compatibility
Tested locally and on cluster