### PR TITLE
Update the Epic Pixel Streaming Infrasture to the latest

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4": "^0.0.3",
-        "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4": "^0.0.3"
+        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4": "^0.0.4",
+        "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4": "^0.0.4"
       },
       "devDependencies": {
         "css-loader": "^6.7.3",
@@ -45,24 +45,24 @@
       }
     },
     "node_modules/@epicgames-ps/lib-pixelstreamingfrontend-ue5.4": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.4/-/lib-pixelstreamingfrontend-ue5.4-0.0.3.tgz",
-      "integrity": "sha512-Llp6aQHjQYg6eYlf8GBB60uQJ+/ueVCPrFnR7SP5muqjXKdBJPXn5hiZpG6tR9Z/soHCyxrudXtGhrObcbsSVg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.4/-/lib-pixelstreamingfrontend-ue5.4-0.0.4.tgz",
+      "integrity": "sha512-PrfrTJ6rf/yxp/GXVDM3hwSyMUooUYd/z90TMxaYcTWU3RbXG8qT85pS5dceGoPwCkwLIiznpWOPOSq70bUupg==",
       "dependencies": {
         "sdp": "^3.1.0"
       }
     },
     "node_modules/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4/-/lib-pixelstreamingfrontend-ui-ue5.4-0.0.3.tgz",
-      "integrity": "sha512-9vVqpI1U2fkz2HvuMlrIcC7DZ+KGKoBobSwS4IFjLQaVDIXm4loDrqlS24hWWNaGNcLi3EyZ5LD6+OtFXYrS7Q==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4/-/lib-pixelstreamingfrontend-ui-ue5.4-0.0.4.tgz",
+      "integrity": "sha512-RFwWo4vY9DRhiVKWWLMBsagpIxiJoQ+GBtI2OmzcgAAb8djGHMDAiljyagwIpTW6r6rxQrl10AGCSlZDKeQSvQ==",
       "dependencies": {
         "jss": "^10.9.2",
         "jss-plugin-camel-case": "^10.9.2",
         "jss-plugin-global": "^10.9.2"
       },
       "peerDependencies": {
-        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4": "^0.0.3"
+        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4": "^0.0.4"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4325,17 +4325,17 @@
       "dev": true
     },
     "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.4/-/lib-pixelstreamingfrontend-ue5.4-0.0.3.tgz",
-      "integrity": "sha512-Llp6aQHjQYg6eYlf8GBB60uQJ+/ueVCPrFnR7SP5muqjXKdBJPXn5hiZpG6tR9Z/soHCyxrudXtGhrObcbsSVg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ue5.4/-/lib-pixelstreamingfrontend-ue5.4-0.0.4.tgz",
+      "integrity": "sha512-PrfrTJ6rf/yxp/GXVDM3hwSyMUooUYd/z90TMxaYcTWU3RbXG8qT85pS5dceGoPwCkwLIiznpWOPOSq70bUupg==",
       "requires": {
         "sdp": "^3.1.0"
       }
     },
     "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4/-/lib-pixelstreamingfrontend-ui-ue5.4-0.0.3.tgz",
-      "integrity": "sha512-9vVqpI1U2fkz2HvuMlrIcC7DZ+KGKoBobSwS4IFjLQaVDIXm4loDrqlS24hWWNaGNcLi3EyZ5LD6+OtFXYrS7Q==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4/-/lib-pixelstreamingfrontend-ui-ue5.4-0.0.4.tgz",
+      "integrity": "sha512-RFwWo4vY9DRhiVKWWLMBsagpIxiJoQ+GBtI2OmzcgAAb8djGHMDAiljyagwIpTW6r6rxQrl10AGCSlZDKeQSvQ==",
       "requires": {
         "jss": "^10.9.2",
         "jss-plugin-camel-case": "^10.9.2",

--- a/library/package.json
+++ b/library/package.json
@@ -14,8 +14,8 @@
   "author": "TensorWorks Pty Ltd",
   "license": "MIT",
   "dependencies": {
-    "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4": "^0.0.3",
-    "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4": "^0.0.3"
+    "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4": "^0.0.4",
+    "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.4": "^0.0.4"
   },
   "devDependencies": {
     "css-loader": "^6.7.3",

--- a/library/src/Messages.ts
+++ b/library/src/Messages.ts
@@ -19,7 +19,7 @@ export enum MessageSendTypes {
 export class MessageStats extends MessageSend {
 	inboundVideoStats: InboundVideoStats;
 	inboundAudioStats: InboundAudioStats;
-	candidatePair: CandidatePairStats
+	candidatePair: CandidatePairStats;
 	dataChannelStats: DataChannelStats;
 	localCandidates: Array<CandidateStat>;
 	remoteCandidates: Array<CandidateStat>;
@@ -33,7 +33,7 @@ export class MessageStats extends MessageSend {
 		this.type = MessageSendTypes.STATS
 		this.inboundVideoStats = aggregatedStats.inboundVideoStats;
 		this.inboundAudioStats = aggregatedStats.inboundAudioStats;
-		this.candidatePair = aggregatedStats.candidatePair;
+		this.candidatePair = aggregatedStats.getActiveCandidatePair();
 		this.dataChannelStats = aggregatedStats.DataChannelStats
 		this.localCandidates = aggregatedStats.localCandidates;
 		this.remoteCandidates = aggregatedStats.remoteCandidates;


### PR DESCRIPTION
## Relevant components:
- [x] Scalable Pixel Streaming Frontend library
- [ ] Examples
- [ ] Docs

## Problem statement:
Currently the Epic Pixel Streaming infrastructure library is `0.0.3`
There is a new version that has been released 

## Solution
Changed the following packages version to `0.0.4`
- lib-pixelstreamingfrontend-ue5.4
- lib-pixelstreamingfrontend-ui-ue5.4

## Documentation

## Test Plan and Compatibility
The library and the example successfully built and ran
