### PR TITLE
Added a link to tensorworks home page

### DIFF
--- a/examples/typescript/src/index.html
+++ b/examples/typescript/src/index.html
@@ -24,8 +24,7 @@
 <body style="background: #2e0052; width: 100vw; height: 100%; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
     <div
         style="position: fixed; bottom: 0; right: 0; padding-right: 10px; padding-bottom: 10px; font-size: 12px; color: #ffffff; z-index: 9999;">
-        <a href="https://scalablestreaming.io/" target="_blank">Scalable Pixel Streaming</a> by <span
-            style="color: #007bff">TensorWorks</span>
+        <a style="color: #5c9ef9" href="https://scalablestreaming.io/" target="_blank">Scalable Pixel Streaming</a> by <a style="color: #5c9ef9" href="https://tensorworks.com.au/" target="_blank">TensorWorks</a>
     </div>
 </body>
 


### PR DESCRIPTION
## Relevant components:
- [ ] Scalable Pixel Streaming Frontend library
- [x] Examples
- [ ] Docs

## Problem statement:
The TensorWorks text is not linked to the `tensorworks.com.au`

## Solution
Surround TensorWorks text with an `anchor` tag with the `herf` to point to `https://tensorworks.com.au/`
The links are also set to a softer blue colour (#5c9ef9)
## Documentation

## Test Plan and Compatibility
The example builds and the `TensorWorks` is a link that opens `https://tensorworks.com.au/` in a new tab
