### PR TITLE
Remove repeated npm from readme

### DIFF
--- a/docs/frontend_utilisation_guide.md
+++ b/docs/frontend_utilisation_guide.md
@@ -68,7 +68,7 @@ These commands and scripts will install and build the library.
 3) Run the following commands in the `examples/typescript` directory of the source tree:
 ```bash
 # Install the examples' dependencies
-npm npm install
+npm install
 
 # Symlink the library to the example
 npm run symlink


### PR DESCRIPTION
## Relevant components:
- [ ] Scalable Pixel Streaming Frontend library
- [ ] Examples
- [x] Docs

## Problem statement:
There was an incorrect command in the detailing how to install the npm dependencies 

## Solution
Remove the duplicate `npm`
