### PR TITLE
Override the stream disconnect event to always allow reconnect attempts. Grammar fixes.

### DIFF
--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -1,4 +1,4 @@
-import { Config, PixelStreaming, SPSApplication, TextParameters, PixelStreamingApplicationStyle, MessageRecv, Flags } from "@tensorworks/libspsfrontend";
+import { Config, PixelStreaming, SPSApplication, TextParameters, PixelStreamingApplicationStyle, MessageRecv, Flags, WebRtcDisconnectedEvent } from "@tensorworks/libspsfrontend";
 
 // Apply default styling from Epic Games Pixel Streaming Frontend
 export const PixelStreamingApplicationStyles = new PixelStreamingApplicationStyle();
@@ -32,6 +32,24 @@ document.body.onload = function () {
 	stream.webSocketController.onConfig = (messageExtendedConfig: MessageExtendedConfig) => {
 		stream.config.setFlagEnabled(Flags.BrowserSendOffer, messageExtendedConfig.frontendToSendOffer);
 		stream.handleOnConfig(messageExtendedConfig);
+	}
+
+	// override the _onDisconnect function to intercept webrtc disconnect events
+	// and modify how the event is fired by always showing a click to reconnect overlay.
+	// we also add a full stop to the AFK message.
+	stream._onDisconnect = function (eventString: string) {
+
+		// check if the eventString coming in is the inactivity string and add a full stop
+		if (eventString == "You have been disconnected due to inactivity") {
+			eventString += "."
+		}
+
+		this._eventEmitter.dispatchEvent(
+			new WebRtcDisconnectedEvent({
+				eventString: eventString,
+				allowClickToReconnect: true
+			})
+		);
 	}
 
 	// Create and append our application

--- a/library/src/index.ts
+++ b/library/src/index.ts
@@ -5,7 +5,7 @@ export { MessageSendTypes, MessageStats } from "./Messages";
 export { MessageAuthRequest, InstanceState, MessageInstanceState, MessageAuthResponseOutcomeType, MessageAuthResponse, MessageRequestInstance, SPSSignalling } from "./SignallingExtension";
 
 // Epic Games Pixel Streaming Frontend exports
-export { WebRtcPlayerController } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.4';
+export { WebRtcPlayerController, WebRtcDisconnectedEvent } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.4';
 export { WebXRController } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.4';
 export { Config, ControlSchemeType, Flags, NumericParameters, TextParameters, OptionParameters, FlagsIds, NumericParametersIds, TextParametersIds, OptionParametersIds, AllSettings } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.4';
 export { SettingBase } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.4';


### PR DESCRIPTION
## Relevant components:
- [x] Scalable Pixel Streaming Frontend library
- [x] Examples
- [ ] Docs

## Problem statement:
Depending on what closure code was returned from a stream disconnect (among other things) would impact whether or not a reconnect attempt is allowed to be made.

There was also a missing full stop for the AFK message.

## Solution
Override the stream disconnect function to always allow a stream reconnect and fix the grammar for the AFK message by adding a full stop.

## Documentation
N/A

## Test Plan and Compatibility
![image](https://github.com/ScalablePixelStreaming/Frontend/assets/85596052/a95f86b1-1c98-4c93-b81a-bc2185943326)
